### PR TITLE
fix lanczos sampling_rate

### DIFF
--- a/obspyDMT/utils/resample_handler.py
+++ b/obspyDMT/utils/resample_handler.py
@@ -79,7 +79,7 @@ def resample_trace(tr, dt, method, lanczos_a=20):
             if method == 'decimate':
                 tr.decimate(factor=decimation_factor, no_filter=True)
             elif method == 'lanczos':
-                current_sr = tr.stats.sampling_rate
+                current_sr = float(tr.stats.sampling_rate)
                 tr.interpolate(method='lanczos',
                                sampling_rate=current_sr/decimation_factor,
                                a=lanczos_a)

--- a/obspyDMT/utils/resample_handler.py
+++ b/obspyDMT/utils/resample_handler.py
@@ -79,8 +79,9 @@ def resample_trace(tr, dt, method, lanczos_a=20):
             if method == 'decimate':
                 tr.decimate(factor=decimation_factor, no_filter=True)
             elif method == 'lanczos':
+                current_sr = tr.stats.sampling_rate
                 tr.interpolate(method='lanczos',
-                               sampling_rate=1./(dt*decimation_factor),
+                               sampling_rate=current_sr/decimation_factor,
                                a=lanczos_a)
         else:
             return tr


### PR DESCRIPTION
I'm not sure if the `lanczos` resampling method is doing right.
For example, I'd like to resample a trace from 100 Hz to 30 Hz.
Since `decimate` couldn't do this, I turned to `lanczos`.
The behavior didn't seem to be right though.

```python
>>> from obspy.core import read
>>> from obspyDMT.utils.resample_handler import resample_unit
>>> tr = read()[0]
>>> resample_unit(tr.copy(), 30, 'decimate').stats.sampling_rate
33.333333333333336
# Old
>>> resample_unit(tr.copy(), 30, 'lanczos').stats.sampling_rate
9.0
# New
>>> resample_unit(tr.copy(), 30, 'lanczos').stats.sampling_rate
30.0
```