### PR TITLE
fix --test False

### DIFF
--- a/obspyDMT/utils/input_handler.py
+++ b/obspyDMT/utils/input_handler.py
@@ -1019,16 +1019,18 @@ def read_input_command(parser, **kwargs):
     else:
         input_dics['max_azi'] = False
 
-    if options.test:
+    if options.test.lower() in ['false']:
+        pass
+    else:
         input_dics['test'] = True
         input_dics['test_num'] = int(options.test)
 
     input_dics['min_date'] = str(UTCDateTime(options.min_date))
     input_dics['max_date'] = str(UTCDateTime(options.max_date))
     input_dics['preset'] = float(options.preset)
-    if options.offset: 
+    if options.offset:
         input_dics['offset'] = float(options.offset)
-    elif options.continuous: 
+    elif options.continuous:
         input_dics['offset'] = 0.
     else:
         input_dics['offset'] = 1800.


### PR DESCRIPTION
`--test False` would throw an error:
```
input_dics['test_num'] = int(options.test)
ValueError: invalid literal for int() with base 10: 'False'
```

https://github.com/kasra-hosseini/obspyDMT/blob/2f0241b38279b364c91dd2ac5e420c3831c8b456/obspyDMT/utils/input_handler.py#L1022-L1024