### PR TITLE
fix when test option is not given

### DIFF
--- a/obspyDMT/utils/input_handler.py
+++ b/obspyDMT/utils/input_handler.py
@@ -1019,7 +1019,7 @@ def read_input_command(parser, **kwargs):
     else:
         input_dics['max_azi'] = False
 
-    if options.test.lower() in ['false']:
+    if not options.test or options.test.lower() in ['false']:
         pass
     else:
         input_dics['test'] = True


### PR DESCRIPTION
A fix to pull request #46 
If `--test` is not given,
it is default to `False`.
But #46 didn't consider it.

https://github.com/kasra-hosseini/obspyDMT/blob/109bb5f7a2dd2627d9cd00136e7cc9995bfca4d3/obspyDMT/utils/input_handler.py#L699