### PR TITLE
fix mkdir FileExistsError

### DIFF
--- a/obspyDMT/process_unit.py
+++ b/obspyDMT/process_unit.py
@@ -1,6 +1,7 @@
 # ------------- required Python and obspy modules are imported in this part
 from obspy.core import read
 import os
+import pathlib
 
 from .utils.instrument_handler import instrument_correction
 from .utils.resample_handler import resample_unit
@@ -62,9 +63,7 @@ def process_unit(tr_add, target_path, input_dics, staev_ar):
     # Before entering to the actual processing part of the code,
     # we define some paths to be used later:
     # you can adjust it as you want, here is just one example
-
-    if not os.path.isdir(os.path.join(target_path, 'processed')):
-        os.mkdir(os.path.join(target_path, 'processed'))
+    pathlib.Path(os.path.join(target_path, 'processed')).mkdir(exist_ok=True)
     # save_path is the address that will be used to save the processed data
     save_path = os.path.join(target_path, 'processed', tr.id)
     if os.path.isfile(save_path) and (not input_dics['force_process']):


### PR DESCRIPTION
As pointed out [here](https://stackoverflow.com/a/273227)

> ...there's a race condition - if the directory is created between the os.path.exists and the os.makedirs calls, the os.makedirs will fail with an OSError. 

And it did happen when run in parallel.
The workaround is from [this answer](https://stackoverflow.com/a/14364249).